### PR TITLE
Upgrade setup-java to v2

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -23,8 +23,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Setup Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: 'temurin'
         java-version: ${{ matrix.jdk }}
 
     - name: Build sonar-kotlin


### PR DESCRIPTION
Updating the [setup-java](https://github.com/actions/setup-java) action to v2. 

- V2 supports custom distributions and provides support for `Zulu OpenJDK`, `Eclipse` `Temurin` and `Adopt OpenJDK`. V1 supports only `Zulu OpenJDK`.
- V1 supported legacy Java syntax such as 1.8 (same as 8) and 1.8.0.212 (same as 8.0.212). V2 dropped support for legacy syntax.
- Switched to `Temurin` which is an official successor of `Adopt OpenJDK`. See [here](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).